### PR TITLE
Use a lock file to prevent concurrent runs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@ venv/
 .DS_Store
 fontc/
 GITHUB_TOKEN
+results/CRATER.lock
 


### PR DESCRIPTION
We want to make sure the same machine is only ever executing one run of the ci script at a time, so we will write a sentinal file when we start execution, and delete it when we're done.