### PR TITLE
Updates 2025-03-20 (29 additional font repos)

### DIFF
--- a/targets.json
+++ b/targets.json
@@ -2464,6 +2464,13 @@
     ]
   },
   {
+    "repo_url": "https://github.com/mooniak/yaldevi-font",
+    "rev": "6be60ebadd35d7c1f8be342436531e16da44a8f7",
+    "config_files": [
+      "builder.yaml"
+    ]
+  },
+  {
     "repo_url": "https://github.com/naipefoundry/gabarito",
     "rev": "1f3fb39d6449eefa880543f109f33ede0cd4064f",
     "config_files": [

--- a/targets.json
+++ b/targets.json
@@ -599,9 +599,14 @@
   },
   {
     "repo_url": "https://github.com/TypeTogether/Playpen-Sans",
-    "rev": "c85bb380b56b2009e7c9bff11f573a3028034161",
+    "rev": "44ce90015ca3bada1ad6f6c608aeccc1df5582ad",
     "config_files": [
-      "config.yml"
+      "config-Arabic.yaml",
+      "config-Deva.yaml",
+      "config-Hebrew.yaml",
+      "config-LGC.yaml",
+      "config-Multi.yaml",
+      "config-Thai.yaml"
     ]
   },
   {

--- a/targets.json
+++ b/targets.json
@@ -3945,6 +3945,13 @@
     ]
   },
   {
+    "repo_url": "https://github.com/tallchai/akshar-type",
+    "rev": "703a8e549e5691fd35eaa4b94983a7d3bdd7190a",
+    "config_files": [
+      "builder.yaml"
+    ]
+  },
+  {
     "repo_url": "https://github.com/theleagueof/league-spartan",
     "rev": "27341b9bf93a2c7faa140538a64ce342486c5fb5",
     "config_files": [

--- a/targets.json
+++ b/targets.json
@@ -3653,6 +3653,13 @@
     ]
   },
   {
+    "repo_url": "https://github.com/productiontype/Georama",
+    "rev": "1b063b6256c228a56d13b8b2f8f1d807f41467f8",
+    "config_files": [
+      "builder.yaml"
+    ]
+  },
+  {
     "repo_url": "https://github.com/productiontype/Spectral",
     "rev": "dbc06862d7030eedb1b01b60cdad8f6102f4ddfa",
     "config_files": [

--- a/targets.json
+++ b/targets.json
@@ -818,6 +818,13 @@
     ]
   },
   {
+    "repo_url": "https://github.com/cyrealtype/Wire-One",
+    "rev": "16db96d77889d4a8de2015ca5f3fc965446437d4",
+    "config_files": [
+      "builder.yaml"
+    ]
+  },
+  {
     "repo_url": "https://github.com/d-sargent/platypi",
     "rev": "c204c7ba647cd05f55a68be6973340fa47aa67d1",
     "config_files": [

--- a/targets.json
+++ b/targets.json
@@ -692,6 +692,13 @@
     ]
   },
   {
+    "repo_url": "https://github.com/benhoepner/National-Park",
+    "rev": "ef0531a85a833b90713743639e3c5ffb8e345833",
+    "config_files": [
+      "config.yaml"
+    ]
+  },
+  {
     "repo_url": "https://github.com/bettergui/BeVietnamPro",
     "rev": "804e62d81abbbcdcce5686069c69b41b8c245192",
     "config_files": [

--- a/targets.json
+++ b/targets.json
@@ -4001,6 +4001,13 @@
     ]
   },
   {
+    "repo_url": "https://github.com/uswds/public-sans",
+    "rev": "f72e00d4f64bf1f880210f4f9e181c7e7037662b",
+    "config_files": [
+      "stat.yaml"
+    ]
+  },
+  {
     "repo_url": "https://github.com/vercel/geist-font",
     "rev": "4ed1df170f23236dc69d3e3e0b3c023d5faf5b3e",
     "config_files": [

--- a/targets.json
+++ b/targets.json
@@ -2457,6 +2457,13 @@
     ]
   },
   {
+    "repo_url": "https://github.com/mooniak/stick-no-bills-font",
+    "rev": "ca59f34fa4d381e6fc695297846c29078c0604be",
+    "config_files": [
+      "builder.yaml"
+    ]
+  },
+  {
     "repo_url": "https://github.com/naipefoundry/gabarito",
     "rev": "1f3fb39d6449eefa880543f109f33ede0cd4064f",
     "config_files": [

--- a/targets.json
+++ b/targets.json
@@ -2264,6 +2264,13 @@
     ]
   },
   {
+    "repo_url": "https://github.com/huertatipografica/Andada-Pro",
+    "rev": "49278d5d3e269f4ebb8b726d7cbc0fbbfa635e9a",
+    "config_files": [
+      "build.yaml"
+    ]
+  },
+  {
     "repo_url": "https://github.com/hyper-type/hahmlet",
     "rev": "f9c5dac25d88015e9f0953253cec1a71854b7d24",
     "config_files": [

--- a/targets.json
+++ b/targets.json
@@ -2448,6 +2448,13 @@
     ]
   },
   {
+    "repo_url": "https://github.com/microsoft/cascadia-code",
+    "rev": "56bcca3f2c1e4cb19458954f0e2bb4635960df91",
+    "config_files": [
+      "stat.yaml"
+    ]
+  },
+  {
     "repo_url": "https://github.com/mooniak/abhaya-libre-font",
     "rev": "edaabf89929778cb947bbd230a257c2a3bbd9979",
     "config_files": [

--- a/targets.json
+++ b/targets.json
@@ -829,6 +829,13 @@
     ]
   },
   {
+    "repo_url": "https://github.com/cyrealtype/Artifika",
+    "rev": "50137a4bf13c4918f78d4b566d14ae3dde703456",
+    "config_files": [
+      "builder.yaml"
+    ]
+  },
+  {
     "repo_url": "https://github.com/cyrealtype/Brawler",
     "rev": "a8e1fc6a4c43dedc38394c4f4086f526b72e852d",
     "config_files": [

--- a/targets.json
+++ b/targets.json
@@ -647,6 +647,13 @@
     ]
   },
   {
+    "repo_url": "https://github.com/aaronbell/LxgwWenkaiTC",
+    "rev": "32516dff7ede6673850c3b88dcbe281150e185a8",
+    "config_files": [
+      "project.yaml"
+    ]
+  },
+  {
     "repo_url": "https://github.com/aaronbell/signika",
     "rev": "bd066259b5a87d24b23c4f0da03a96889b6d0503",
     "config_files": [

--- a/targets.json
+++ b/targets.json
@@ -633,6 +633,13 @@
     ]
   },
   {
+    "repo_url": "https://github.com/aaronbell/CactusSerif",
+    "rev": "1d5b4158aa0411f7b1279f4bfa3f49416ba0b15d",
+    "config_files": [
+      "project.yaml"
+    ]
+  },
+  {
     "repo_url": "https://github.com/aaronbell/signika",
     "rev": "bd066259b5a87d24b23c4f0da03a96889b6d0503",
     "config_files": [

--- a/targets.json
+++ b/targets.json
@@ -1388,6 +1388,13 @@
     ]
   },
   {
+    "repo_url": "https://github.com/googlefonts/bakbak",
+    "rev": "b53b9c31c16f0021b7c206a57a8f04a4d382bc67",
+    "config_files": [
+      "builder.yaml"
+    ]
+  },
+  {
     "repo_url": "https://github.com/googlefonts/bangers",
     "rev": "ca6d2f15db343ee373e9c62a127f3a48cd251228",
     "config_files": [

--- a/targets.json
+++ b/targets.json
@@ -1759,6 +1759,21 @@
     ]
   },
   {
+    "repo_url": "https://github.com/googlefonts/lexend",
+    "rev": "7894f02b2e7eabc48595f1d4eff3b17b48c6e651",
+    "config_files": [
+      "deca.yaml",
+      "exa.yaml",
+      "giga.yaml",
+      "lexend-1axis.yaml",
+      "lexend.yaml",
+      "mega.yaml",
+      "peta.yaml",
+      "tera.yaml",
+      "zetta.yaml"
+    ]
+  },
+  {
     "repo_url": "https://github.com/googlefonts/licorice",
     "rev": "8bc5263602a190f212684ea69d5b9d3b21a59bc0",
     "config_files": [

--- a/targets.json
+++ b/targets.json
@@ -300,6 +300,13 @@
     ]
   },
   {
+    "repo_url": "https://github.com/NDISCOVER/Arima-Font",
+    "rev": "c5fd72960f129076fbf3759d6d777cedcbceb468",
+    "config_files": [
+      "builder.yaml"
+    ]
+  },
+  {
     "repo_url": "https://github.com/NDISCOVER/Exo-1.0",
     "rev": "3be4f55b626129f17a3b82677703e48c03dc2052",
     "config_files": [

--- a/targets.json
+++ b/targets.json
@@ -29,6 +29,13 @@
     ]
   },
   {
+    "repo_url": "https://github.com/AlistairMcCready/Special-Gothic",
+    "rev": "805adb65b7262a7abf1c37877ff657111bfcf864",
+    "config_files": [
+      "config.yaml"
+    ]
+  },
+  {
     "repo_url": "https://github.com/BornaIz/markazitext",
     "rev": "a876c4f0111b96f407741a877e79f207e9117338",
     "config_files": [

--- a/targets.json
+++ b/targets.json
@@ -3764,6 +3764,13 @@
     ]
   },
   {
+    "repo_url": "https://github.com/rosettatype/eczar",
+    "rev": "f248ec9c0c5e3a9442d22824cc1cba6c713725d5",
+    "config_files": [
+      "builder.yaml"
+    ]
+  },
+  {
     "repo_url": "https://github.com/rsms/inter-gf-tight",
     "rev": "c194f94c60b569b47876811321f5ef1f0c2614a2",
     "config_files": [

--- a/targets.json
+++ b/targets.json
@@ -180,6 +180,16 @@
     ]
   },
   {
+    "repo_url": "https://github.com/Gue3bara/Blaka",
+    "rev": "7f264eee862d3e94c2cb6a728c6429c2f3b9adc3",
+    "config_files": [
+      "black.yaml",
+      "blakahollow.yaml",
+      "blakaink.yaml",
+      "blakaregular.yaml"
+    ]
+  },
+  {
     "repo_url": "https://github.com/Gue3bara/El-Messiri",
     "rev": "553b98d8e374318694b50862849af666268fd278",
     "config_files": [

--- a/targets.json
+++ b/targets.json
@@ -972,6 +972,14 @@
     ]
   },
   {
+    "repo_url": "https://github.com/etunni/diplomata",
+    "rev": "32dc35e6b420631acc10808e1f92f74e3048e81d",
+    "config_files": [
+      "diplomata.yaml",
+      "diplomatasc.yaml"
+    ]
+  },
+  {
     "repo_url": "https://github.com/etunni/graduate",
     "rev": "d6031c4ce60208e8e68f5e4dee771420d22c3815",
     "config_files": [

--- a/targets.json
+++ b/targets.json
@@ -836,6 +836,13 @@
     ]
   },
   {
+    "repo_url": "https://github.com/cyrealtype/Aubrey",
+    "rev": "1946b0d99c0fec87702a59afc8b5b941a32e0171",
+    "config_files": [
+      "builder.yaml"
+    ]
+  },
+  {
     "repo_url": "https://github.com/cyrealtype/Brawler",
     "rev": "a8e1fc6a4c43dedc38394c4f4086f526b72e852d",
     "config_files": [

--- a/targets.json
+++ b/targets.json
@@ -3667,6 +3667,15 @@
     ]
   },
   {
+    "repo_url": "https://github.com/reddit/redditsans",
+    "rev": "60e19b50bde6de34b695591a8a047a6a3618a37c",
+    "config_files": [
+      "mono.yaml",
+      "sans.yaml",
+      "sanscondensed.yaml"
+    ]
+  },
+  {
     "repo_url": "https://github.com/redstonedesign/parkinsans",
     "rev": "9b5ec433f1944dfc0453ef3ce15f67a0649c13b0",
     "config_files": [

--- a/targets.json
+++ b/targets.json
@@ -2455,6 +2455,13 @@
     ]
   },
   {
+    "repo_url": "https://github.com/mooniak/gemunu-libre-font",
+    "rev": "90f5ecf8fbf25bc1c5e0b3540a7657fb19d62e23",
+    "config_files": [
+      "builder.yaml"
+    ]
+  },
+  {
     "repo_url": "https://github.com/mooniak/maname-font",
     "rev": "626ceee1311626c5240a68b0ef27722f44c374af",
     "config_files": [

--- a/targets.json
+++ b/targets.json
@@ -762,6 +762,13 @@
     ]
   },
   {
+    "repo_url": "https://github.com/coz-m/MPLUS_FONTS",
+    "rev": "56b8226f4fae1111e38fddb3dae8a09e170bec5b",
+    "config_files": [
+      "MPLUS_STAT.yaml"
+    ]
+  },
+  {
     "repo_url": "https://github.com/cyrealtype/Alice",
     "rev": "19421efc21eeeb872773006539ddcd743fb72440",
     "config_files": [

--- a/targets.json
+++ b/targets.json
@@ -987,6 +987,14 @@
     ]
   },
   {
+    "repo_url": "https://github.com/etunni/mate",
+    "rev": "2ea8febc952610379af663b1651411493d34beea",
+    "config_files": [
+      "mate.yaml",
+      "matesc.yaml"
+    ]
+  },
+  {
     "repo_url": "https://github.com/etunni/merienda",
     "rev": "15f2f36d29595fa3dd6cf068323ef44bc0713b56",
     "config_files": [

--- a/targets.json
+++ b/targets.json
@@ -190,6 +190,14 @@
     ]
   },
   {
+    "repo_url": "https://github.com/Gue3bara/Cairo",
+    "rev": "73d16933c6a0f341c27a69e401da83dcb0d53114",
+    "config_files": [
+      "cairo.yaml",
+      "cairoplay.yaml"
+    ]
+  },
+  {
     "repo_url": "https://github.com/Gue3bara/El-Messiri",
     "rev": "553b98d8e374318694b50862849af666268fd278",
     "config_files": [

--- a/targets.json
+++ b/targets.json
@@ -944,6 +944,13 @@
     ]
   },
   {
+    "repo_url": "https://github.com/erinmclaughlin/BhuTuka-Extended-One",
+    "rev": "ac2ad17bcd23da70b2c63a4ed794cbb7a7ebaac6",
+    "config_files": [
+      "builder.yaml"
+    ]
+  },
+  {
     "repo_url": "https://github.com/etunni/Amita",
     "rev": "92680c07f01285a23744cda1190690c5c7f3f73c",
     "config_files": [

--- a/targets.json
+++ b/targets.json
@@ -271,6 +271,14 @@
     ]
   },
   {
+    "repo_url": "https://github.com/KanonFoundry/HedvigLetters",
+    "rev": "5331b7044a8f97dafc8587c70aef62a828084fd4",
+    "config_files": [
+      "Sans.yaml",
+      "Serif.yaml"
+    ]
+  },
+  {
     "repo_url": "https://github.com/Kief-Type-Foundry/Fustat",
     "rev": "8e5354428eb81c3ebf9edbc86bfa9cdca23ce8b1",
     "config_files": [

--- a/targets.json
+++ b/targets.json
@@ -3980,6 +3980,13 @@
     ]
   },
   {
+    "repo_url": "https://github.com/typofactur/winkyrough",
+    "rev": "505f77bdee3b09d4290a9a6813d1eded2dea81b5",
+    "config_files": [
+      "config.yaml"
+    ]
+  },
+  {
     "repo_url": "https://github.com/typofactur/winkysans",
     "rev": "0c6c255d031c0328fcfcfbee5fbb87289ff18bc2",
     "config_files": [

--- a/targets.json
+++ b/targets.json
@@ -640,6 +640,13 @@
     ]
   },
   {
+    "repo_url": "https://github.com/aaronbell/ChocolateSans",
+    "rev": "91c9c5179adc1b2af2de1e3972d91e5e62c7bbc4",
+    "config_files": [
+      "project.yaml"
+    ]
+  },
+  {
     "repo_url": "https://github.com/aaronbell/signika",
     "rev": "bd066259b5a87d24b23c4f0da03a96889b6d0503",
     "config_files": [


### PR DESCRIPTION
The majority of these are using files equivalent to `sources/config.yaml` but with unconventional file names. They were detected with the changes made to **google-fonts-sources** at https://github.com/googlefonts/google-fonts-sources/pull/54

This PR also includes a few new repos that were actually published since the last update.